### PR TITLE
Global metrics and historical data

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -83,6 +83,19 @@ DailyPulse.prototype.getMoodKPI=function(site_id,callBack){
     );
 }
 
+
+/**
+ * Returns the current global Mood KPI for all the sites of the account.
+ */
+DailyPulse.prototype.getGlobalMoodKPI=function(callBack){
+    this.getClient().get({
+            path:'/latest/mood'
+        }, function (err, req, res, obj) {
+            callBack(err,obj);
+        }
+    );
+}
+
 /**
  * Return the current
  */
@@ -97,11 +110,36 @@ DailyPulse.prototype.getPulsesPerTypicalDay=function(site_id,callBack){
 
 
 /**
+ * Return the current global pulses per typical day for all the sites of the account
+ */
+DailyPulse.prototype.getGlobalPulsesPerTypicalDay=function(callBack){
+    this.getClient().get({
+            path:'/latest/pulsesperday'
+        }, function (err, req, res, obj) {
+            callBack(err,obj);
+        }
+    );
+}
+
+
+/**
  * Returns the historical Mood KPI of a given site and the number of days to fetch since today.
  */
 DailyPulse.prototype.getHistoricalMoodKPI=function(site_id,days_to_fetch,callBack){
     this.getClient().get({
-            path:'/historical/mood/'+site_id+'/'+days_to_fetch
+            path:'/historical/mood/'+days_to_fetch+'/'+site_id
+        }, function (err, req, res, obj) {
+            callBack(err,obj);
+        }
+    );
+}
+
+/**
+ * Returns the historical global Mood KPI of all the sites od the account, and the number of days to fetch since today.
+ */
+DailyPulse.prototype.getHistoricalGlobalMoodKPI=function(days_to_fetch,callBack){
+    this.getClient().get({
+            path:'/historical/mood/'+days_to_fetch
         }, function (err, req, res, obj) {
             callBack(err,obj);
         }
@@ -113,7 +151,7 @@ DailyPulse.prototype.getHistoricalMoodKPI=function(site_id,days_to_fetch,callBac
  */
 DailyPulse.prototype.getHistoricalPulsesPerTypicalDay=function(site_id,days_to_fetch,callBack){
     this.getClient().get({
-            path:'/historical/pulsesperday/'+site_id+'/'+days_to_fetch
+            path:'/historical/pulsesperday/'+days_to_fetch+'/'+site_id
         }, function (err, req, res, obj) {
             callBack(err,obj);
         }
@@ -121,5 +159,16 @@ DailyPulse.prototype.getHistoricalPulsesPerTypicalDay=function(site_id,days_to_f
 }
 
 
+/**
+ * Returns the historical Pulses per Day of a given site and the number of days to fetch since today
+ */
+DailyPulse.prototype.getHistoricalGlobalPulsesPerTypicalDay=function(days_to_fetch,callBack){
+    this.getClient().get({
+            path:'/historical/pulsesperday/'+days_to_fetch
+        }, function (err, req, res, obj) {
+            callBack(err,obj);
+        }
+    );
+}
 
 module.exports=DailyPulse;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dailypulse",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "description":"Celpax DailyPulse NodeJS API Client",
     "author": {
         "name": "rafael@celpax.com"

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,6 @@ var dailyPulseClient=new DailyPulse(access_key_id,secret_access_key);
 You can download your access and secret api keys from DailyPulse dashboard.
 
 ## Get your sites
-
 DailyPulse can be deployed on one or more company sites. In either case you will need to know the Site ID before you can download metrics related to it.
 
 You can get your sites as follows:
@@ -48,6 +47,15 @@ You can retrieve the latest calculated Mood KPI for a given site as follows:
 
 Note that in some cases the Mood KPI cannot be calculated (for example during rollout) and will be returned as null. A date member will also be included indicating when the Mood KPI was last updated.
 
+Alternatively, you can retrieve the latest calculated global Mood KPI of all the sites of the account as follows:
+
+```javascript
+    dailyPulseClient.getGlobalMoodKPI(function(err,mood){
+        // err should be null if everthing went OK!
+        if(mood.green > 70) Console.log("We are going very well!!");
+    });
+```
+
 ## Historical Mood KPI
 
 You can retrieve the historical calculated Mood KPI for a given site and the number of days to fetch since today as follows:
@@ -61,6 +69,14 @@ You can retrieve the historical calculated Mood KPI for a given site and the num
 
 The maximum number of allowed days to be fetched can be configured in the Celpax Dashboard console. You need administrator privileges for accessing to the configuration section. 
 
+Alternatively you can retrieve the historical calculated global mood KPI of all the sites of the account as follows:
+
+```javascript
+    dailyPulseClient.getHistoricalGlobalMoodKPI(numberOfDaysToFetch,function(err,moodArray){ 
+        // err should be null if everthing went OK!
+        if(moodArray[0].green > 70) Console.log("We are going very well!!");
+    });
+```
 
 ## Pulses in a Typical Day
 
@@ -78,6 +94,14 @@ dailyPulseClient.getPulsesPerTypicalDay(site.id,function(err,typicalday){
 ```
 A date member will also be returned indicating when the pulses per typical day was last updated.
 
+Alternatively, you can retrieve the global pulses in a typical day of all the sites of the account as follows:
+ 
+```javascript
+dailyPulseClient.getGlobalPulsesPerTypicalDay(function(err,typicalday){
+    // Some dates may not have a PulsesPerTypicalDay calculated,
+    console.log("Normally there are:"+typicalday.pulses + "pulses in a typical day");
+});
+```
 ## Historical Pulses in a Typical Day
 
 You can retrieve the historical Pulses in a Typical day for a given site and the number of days to fetch since today as follows:
@@ -91,6 +115,19 @@ dailyPulseClient.getHistoricalPulsesPerTypicalDay(mySite.id,numberOfDaysToFetch,
 
 The maximum number of allowed days to be fetched can be configured in the Celpax Dashboard console. You need administrator privileges for accessing to the configuration section. 
 
+Alternatively, you can retrieve the historical global pulses per typical day of all the sites of the account as follows:
+```javascript
+dailyPulseClient.getHistoricalGlobalPulsesPerTypicalDay(numberOfDaysToFetch,function(err,typicaldayArray){
+    // Some dates may not have a PulsesPerTypicalDay calculated,
+    console.log("Normally there are:"+typicaldayArray[0].pulses + "pulses in a typical day");
+});
+```
+
+## User Interface Design
+
+We have released user interface elements, such as: colours, fonts, widgets available in the github project: [DailyPulse-Resources](https://github.com/celpax/dailypulse-resources)
+
+The resources provided match the User Interface of the DailyPulse Dashboard.
 
 
 ## Testing

--- a/test/APITest.js
+++ b/test/APITest.js
@@ -111,3 +111,79 @@ describe("DailyPulse API test",function(){
     });
 });
 
+describe("DailyPulse global data API test",function(){
+
+    /**
+     * Create a DailyPulse client instance using your account keys.
+     * @type {DailyPulse}
+     */
+
+    var dailyPulseClient=new DailyPulse(access_key_id,secret_access_key);
+
+
+    it("Will get the global mood KPI",function(done){
+        dailyPulseClient.getGlobalMoodKPI(function(err,mood){
+            expect(err).to.be.null;
+            expect(mood.date).not.to.be.null;
+            // Some dates may not have a KPI calculated, in which case read and green is returned as null
+            if(mood.green){
+                // if they are returned they follow:
+                // both values with be rounded and returned matching the ones on the console
+                // they must sum 100%
+                expect(mood.green).to.be.equal(100-mood.red);
+                console.log("Mood KPI result:"+JSON.stringify(mood));
+
+            }
+            done();
+        });
+    });
+
+    it("Will get the global pulses per typical day",function(done){
+        dailyPulseClient.getGlobalPulsesPerTypicalDay(function(err,typicalday){
+            expect(err).to.be.null;
+            expect(typicalday.date).not.to.be.null;
+            // Some dates may not have a PulsesPerTypicalDay calculated,
+            if(typicalday.pulses){
+                // if they are returned they follow:
+                expect(typicalday.pulses).to.be.a("number");
+            }
+            console.log("Typical day result:"+JSON.stringify(typicalday));
+
+            done();
+        })
+    });
+
+    var numberOfDaysToFetch = 28;
+
+    it("Will get the historical global mood KPI",function(done){
+        dailyPulseClient.getHistoricalGlobalMoodKPI(numberOfDaysToFetch,function(err,moodArray){
+            expect(err).to.be.null;
+            expect(moodArray[0].date).not.to.be.null;
+            // Some dates may not have a KPI calculated, in which case read and green is returned as null
+            if(moodArray[0].green){
+                // if they are returned they follow:
+                // both values with be rounded and returned matching the ones on the console
+                // they must sum 100%
+                expect(moodArray[0].green).to.be.equal(100-moodArray[0].red);
+                console.log("Historical Mood KPI result:"+JSON.stringify(moodArray));
+
+            }
+            done();
+        });
+    });
+
+    it("Will get the historical global pulses per typical day",function(done){
+        dailyPulseClient.getHistoricalGlobalPulsesPerTypicalDay(numberOfDaysToFetch,function(err,typicaldayArray){
+            expect(err).to.be.null;
+            expect(typicaldayArray[0].date).not.to.be.null;
+            // Some dates may not have a PulsesPerTypicalDay calculated,
+            if(typicaldayArray[0].pulses){
+                // if they are returned they follow:
+                expect(typicaldayArray[0].pulses).to.be.a("number");
+            }
+            console.log("Historical Typical day result:"+JSON.stringify(typicaldayArray));
+
+            done();
+        })
+    });
+});


### PR DESCRIPTION
implemented the calls for retrieving:
* the global Mood KPI for all the sites of the account.
* the global typical pulses per day of all the sites of the account.
* historical access to the Mood KPI and the typical pulses per day metrics for an specific site and for all the sites of the account.

All these features have been tested and documented.

